### PR TITLE
Removed image plugin inclusion duplication

### DIFF
--- a/tests/manual/removeformat.js
+++ b/tests/manual/removeformat.js
@@ -27,7 +27,7 @@ ClassicEditor
 	.create( global.document.querySelector( '#editor' ), {
 		plugins: [
 			Bold, Clipboard, Enter, Italic, Link, Paragraph, RemoveFormat, ShiftEnter, Typing,
-			Underline, Undo, Image, Image, ImageCaption, ImageToolbar
+			Underline, Undo, Image, ImageCaption, ImageToolbar
 		],
 		toolbar: [ 'removeFormat', '|', 'italic', 'bold', 'link', 'underline', '|', 'undo', 'redo' ]
 	} )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Removed image plugin inclusion duplication.

---

### Additional information

While browsing the test I stumbled upon this line. The plugin image was included twice.