### PR TITLE
i/353: Focus the editor before executing a command

### DIFF
--- a/src/removeformatui.js
+++ b/src/removeformatui.js
@@ -47,7 +47,10 @@ export default class RemoveFormatUI extends Plugin {
 			view.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
 
 			// Execute the command.
-			this.listenTo( view, 'execute', () => editor.execute( REMOVE_FORMAT ) );
+			this.listenTo( view, 'execute', () => {
+				editor.execute( REMOVE_FORMAT );
+				editor.editing.view.focus();
+			} );
 
 			return view;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Focus the editor before executing toolbar buttons' command. 

### Additonal information:
Master PR: https://github.com/ckeditor/ckeditor5/pull/6066
