### PR TITLE
Internal: Removed eslint-plugin-ckeditor5-rules dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^18.0.0",
     "@ckeditor/ckeditor5-ui": "^18.0.0",
-    "@ckeditor/ckeditor5-utils": "^18.0.0",
-    "eslint-plugin-ckeditor5-rules": "^0.0.2"
+    "@ckeditor/ckeditor5-utils": "^18.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^18.0.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Removed the `eslint-plugin-ckeditor5-rules` dependency.

---

### Additional information

It's not needed. Firstly it's a dev dependency, secondly it's included by eslint-config-ckeditor5 package.